### PR TITLE
Bumps up to v0.10.2

### DIFF
--- a/ghr.rb
+++ b/ghr.rb
@@ -2,10 +2,10 @@ require "formula"
 
 class Ghr < Formula
   homepage "https://github.com/tcnksm/ghr"
-  version 'v0.5.4'
+  version 'v0.10.2'
 
-  url "https://github.com/tcnksm/ghr/releases/download/v0.5.4/ghr_v0.5.4_darwin_amd64.zip"
-  sha256 "c473cd89813e1c94f30887d53a8cd0fced2a8ec6cd100444ba81ce45b32f09eb"
+  url "https://github.com/tcnksm/ghr/releases/download/v0.10.2/ghr_v0.10.2_darwin_amd64.zip"
+  sha256 "1cb1115591624eaa0b836f5e6f375cc1c66eff1257a63e2393b07c3ac9491ea9"
 
   def install
     bin.install 'ghr'


### PR DESCRIPTION
I just noticed that the current formula points to v0.5.4, so updated it to the latest version! 👍 